### PR TITLE
Fix error when running with Ruby 1.9.x on the server side

### DIFF
--- a/lib/puppet/provider/package/powershellcore.rb
+++ b/lib/puppet/provider/package/powershellcore.rb
@@ -60,7 +60,7 @@ Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::P
 
   def install_command
     command = "Install-Module #{@resource[:name]} -Scope AllUsers -Force"
-    command << " -RequiredVersion #{@resource[:ensure]}" unless %i[present latest].include? @resource[:ensure]
+    command << " -RequiredVersion #{@resource[:ensure]}" unless [:present, :latest].include? @resource[:ensure]
     command << " -Repository #{@resource[:source]}" if @resource[:source]
     command
   end


### PR DESCRIPTION
Closes #15 

Found out that `%i[]` is for Ruby 2.0 only.

Puppet Server runs JRuby 1.7 which is Ruby 1.9.x and, for some reason, the package provider code is executed by the Server. This means Ruby 2.0 features can't be used in those files.