### PR TITLE
Added support for install_options argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ file{"C:\Program Files\PackageManagement\ProviderAssemblies\nuget\2.8.5.208\Micr
 
 `puppet-powershellmodule` implements a [package type](http://docs.puppet.com/references/latest/type.html#package) with a resource provider, which is built into Puppet.
 
+The implementation supports the [install_options](https://puppet.com/docs/puppet/6.2/type.html#package-attribute-install_options) attribute which can be used to pass additional options to the PowerShell Install-Modules command, e.g.:
+
+```
+package { 'xPSDesiredStateConfiguration':
+  ensure   => latest,
+  provider => 'windowspowershell',
+  source   => 'PSGallery',
+  install_options => [ '-AllowClobber',
+                       { '-proxy' => 'http://proxy.local.domain' }  ]
+}
+
+```
+
 ### pspackageprovider
 
 #### Properties/Parameters

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ package { 'xPSDesiredStateConfiguration':
   ensure   => latest,
   provider => 'windowspowershell',
   source   => 'PSGallery',
+  install_options => [ '-AllowClobber' ]
 }
 
 package { 'Pester':

--- a/lib/puppet/provider/package/powershellcore.rb
+++ b/lib/puppet/provider/package/powershellcore.rb
@@ -55,10 +55,10 @@ Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::P
   # @param options [Array]
   # @return Concatenated list of options
   # @api private
-  def install_options
-    return unless @resource[:install_options]
+  def install_options(options)
+    return unless options
 
-    @resource[:install_options].collect do |val|
+    options.collect do |val|
       case val
         when Hash
           val.keys.sort.collect do |k|
@@ -88,7 +88,7 @@ Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::P
     command = "Install-Module #{@resource[:name]} -Scope AllUsers -Force"
     command << " -RequiredVersion #{@resource[:ensure]}" unless [:present, :latest].include? @resource[:ensure]
     command << " -Repository #{@resource[:source]}" if @resource[:source]
-    command << " #{install_options}" if @resource[:install_options]
+    command << " #{install_options(@resource[:install_options])}" if @resource[:install_options]
     command
   end
 
@@ -103,7 +103,7 @@ Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::P
   def update_command
     command = "Install-Module #{@resource[:name]} -Scope AllUsers -Force"
     command << " -Repository #{@resource[:source]}" if @resource[:source]
-    command << " #{install_options}" if @resource[:install_options]
+    command << " #{install_options(@resource[:install_options])}" if @resource[:install_options]
     command
   end
 end

--- a/lib/puppet/provider/package/windowspowershell.rb
+++ b/lib/puppet/provider/package/windowspowershell.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:package).provide(:windowspowershell, parent: :powershellcore)
   initvars
   confine operatingsystem: :windows
   confine feature: :powershellgetwindows
-  has_feature :installable, :uninstallable, :upgradeable, :versionable
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
   commands powershell: 'powershell'
 
   def self.invoke_ps_command(command)


### PR DESCRIPTION
install_options can now be specified to allow additional arguments to be passed to the PowerShell Install-Module command, e.g.

    package { 'foobarmodule':
        ensure => latest,
        provider => 'windowspowershell',
        source => 'PSGallery',
        install_options => [ '-AllowClobber' ]
    }