### PR TITLE
Allow SecurityProtocol to be specified for a repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ psrepository { 'my-internal-repo':
 }
 ```
 
+If the PowerShell repository enforces a specific security protocol, e.g. TLS 1.2, then this can be specified using the securityprotocols parameter, see [SecurityProtocolType Enum](https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype) for a list of allowed values.
+
+```puppet
+psrepository { 'my-internal-repo':
+  ensure              => present,
+  source_location     => 'http://myrepo.corp.com/api/nuget/powershell',
+  installation_policy => 'trusted',
+  provider            => 'windowspowershell',
+  securityprotocols   => [ 'Tls12' ]
+}
+```
+
 Manifests can then refer to that repository using the `package` resource.
 
 ```puppet
@@ -234,6 +246,10 @@ The url to the repository that you would like to register. Must be a valid HTTP 
 #### `installation_policy`
 
 Manages the installation policy used for the PSRepository. Valid values are `trusted` or `untrusted`
+
+#### `securityprotocols`
+
+An optional array of security protocols to use when accessing the repository.  Values specified will be used to set the [ServicePointManager.SecurityProtocol](https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.securityprotocol) property, if this parameter is not specified then the system default protocol will be used.
 
 ### Providers
 #### `windowspowershell`

--- a/lib/puppet/type/psrepository.rb
+++ b/lib/puppet/type/psrepository.rb
@@ -34,4 +34,16 @@ Puppet::Type.newtype(:psrepository) do
     defaultto :untrusted
     newvalues(:trusted, :untrusted)
   end
+  
+  newparam(:securityprotocols, :array_matching => :all) do
+    desc "An array of security protocols which should be used when accessing the PS repository.
+      See: https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netframework-4.7.2.
+      e.g. securityprotocols => [Tls,Tls11,TLS12]
+      If this is not specified the system default TLS settings will be used."
+
+    # Make sure we convert to an array.
+    munge do |value|
+      [value].flatten
+    end
+  end  
 end


### PR DESCRIPTION
A parameter (securityprotocols) has been added to the psrepository type
which will accept a list of security protocols that the repository will
accept, the list can contain any values can be specified for the
ServicePointManager.SecurityProtocol Property (see
https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.securityprotocol)

e.g.

    psrepository { 'psrepo':
        ensure              => present,
        source_location     => 'https://local.repo.domain/',
        installation_policy => 'trusted',
        securityprotocols   => [ TLS11, TLS12 ]
    }

This is to resolve an SSL connection issue that can occur if the
PowerShell repository enforces the use of a specific TLS version, but
the Windows client has a default protocol version that is lower.