### PR TITLE
WIP: Delete name of the resource after command

### DIFF
--- a/lib/puppet/provider/psrepository/powershellcore.rb
+++ b/lib/puppet/provider/psrepository/powershellcore.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:psrepository).provide(:powershellcore) do
 
   def flush
     unless @property_flush.empty?
-      flush_command = "Set-PSRepository #{@resource[:name]}"
+      flush_command = "Set-PSRepository"
       @property_flush.each do |key, value|
         flush_command << " -#{key} '#{value}'"
       end


### PR DESCRIPTION
Should always include parameter 'name' so it would run 'Set-PSRepository -name ..' instead of 'Set-PSRepository "resource name"' which doesn't work with powershell 5.0