### PR TITLE
Ignore warnings with Get-PSRepository and Get-Package.

### DIFF
--- a/lib/puppet/provider/package/powershellcore.rb
+++ b/lib/puppet/provider/package/powershellcore.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:package).provide :powershellcore, parent: Puppet::Provider::P
   def self.instances_command
     # Get-Package is way faster than Get-InstalledModule
     <<-COMMAND
-    Get-Package -AllVersions -ProviderName PowerShellGet -Scope AllUsers -Type Module |
+    Get-Package -AllVersions -ProviderName PowerShellGet -Scope AllUsers -Type Module -WarningAction 'SilentlyContinue' |
     Group-Object -Property Name | % {
       [ordered]@{
         'name' = $_.Name

--- a/lib/puppet/provider/psrepository/powershellcore.rb
+++ b/lib/puppet/provider/psrepository/powershellcore.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:psrepository).provide(:powershellcore) do
 
   def self.instances_command
     <<-COMMAND
-    @(Get-PSRepository).foreach({
+    @(Get-PSRepository -WarningAction SilentlyContinue).foreach({
       [ordered]@{
         'name' = $_.Name
         'source_location' = $_.SourceLocation


### PR DESCRIPTION
As per [Issue 22](https://github.com/hbuckle/puppet-powershellmodule/issues/22) when server does not have internet access, Get-PSRepository throws two warnings which cause fatal errors in execution.