### PR TITLE
Fixing powershellgetwindows feature to not error on powershell < 5.1

### DIFF
--- a/lib/puppet/feature/powershellgetwindows.rb
+++ b/lib/puppet/feature/powershellgetwindows.rb
@@ -1,7 +1,7 @@
 require 'puppet/util/feature'
 
 Puppet.features.add(:powershellgetwindows) do
-  command = '"Import-Module powershellget; $mod = Get-Module powershellget; $mod.Name"'
+  command = '"try { Import-Module powershellget -ErrorAction Stop; $mod = Get-Module powershellget; $mod.Name; } catch {}"'
   output = `powershell.exe -noprofile -executionpolicy bypass -command #{command}`
   output.downcase.strip == 'powershellget'
 end


### PR DESCRIPTION
Previously i would get the following error on Windows 2012r2 servers:

```
puppet.bat : Import-Module : The specified module 'powershellget' was not loaded because no 
At line:1 char:1
+ puppet facts upload
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Import-Module :...ded because no :String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
valid module file was found in any module directory.
At line:1 char:1
+ Import-Module powershellget; $mod = Get-Module powershellget; $mod.Name
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (powershellget:String) [Imp 
   ort-Module], FileNotFoundException
    + FullyQualifiedErrorId : Modules_ModuleNotFound,Microsoft.PowerShell.Comm 
   ands.ImportModuleCommand
```

With the fixes (wrapping in try/catch) if the `powershellget` module is missing, the feature is not enabled and no error is shown.